### PR TITLE
Add github actions configuration

### DIFF
--- a/.github/workflows/scala.yml
+++ b/.github/workflows/scala.yml
@@ -1,0 +1,41 @@
+name: Test Telemetry Samples
+
+on: [push, pull_request]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: sbt cache
+        uses: actions/cache@v2
+        env:
+          cache-name: sbt-dependencies-cache
+        with:
+          path: |
+            ~/.ivy2/cache
+            ~/.sbt
+            ~/.cache/coursier/v1
+          key: ${{ runner.os }}-sbt-${{ env.cache-name }}
+
+      - name: Install AdoptOpenJDK 11
+        uses: AdoptOpenJDK/install-jdk@v1
+        with:
+          version: "11"
+
+      - name: Start docker-compose services
+        run: |
+          pushd lagom/shopping-cart-scala && docker-compose up -d && popd
+          sleep 30
+
+      - name: Check docker-compose services
+        run: pushd lagom/shopping-cart-scala && docker-compose ps && popd
+
+      - name: Run tests for lagom/shopping-cart-scala
+        run: pushd lagom/shopping-cart-scala && sbt test && popd
+        env:
+          LIGHTBEND_COMMERCIAL_MVN: ${{ secrets.LIGHTBEND_COMMERCIAL_MVN }}
+          LIGHTBEND_COMMERCIAL_IVY: ${{ secrets.LIGHTBEND_COMMERCIAL_IVY }}

--- a/lagom/shopping-cart-scala/credentials.sbt
+++ b/lagom/shopping-cart-scala/credentials.sbt
@@ -1,2 +1,11 @@
-credentials in ThisBuild += Credentials(Path.userHome / ".lightbend" / "commercial.credentials")
-resolvers in ThisBuild += "lightbend-commercial-maven" at "https://repo.lightbend.com/commercial-releases"
+resolvers in ThisBuild ++= {
+    val mvnResolver = sys.env.get("LIGHTBEND_COMMERCIAL_MVN").map { url =>
+        "lightbend-commercial-mvn" at url
+    }
+
+    val ivyResolver = sys.env.get("LIGHTBEND_COMMERCIAL_IVY").map { u =>
+        Resolver.url("lightbend-commercial-ivy", url(u))(Resolver.ivyStylePatterns)
+    }
+
+    (mvnResolver ++ ivyResolver).toList
+}

--- a/lagom/shopping-cart-scala/shopping-cart/src/main/scala/com/example/shoppingcart/impl/ShoppingCartReportProcessor.scala
+++ b/lagom/shopping-cart-scala/shopping-cart/src/main/scala/com/example/shoppingcart/impl/ShoppingCartReportProcessor.scala
@@ -9,7 +9,10 @@ import com.example.shoppingcart.impl.ShoppingCart._
 
 import scala.util.Random
 
-class ShoppingCartReportProcessor(readSide: SlickReadSide, repository: ShoppingCartReportRepository)
+import play.api.Mode
+import play.api.Environment
+
+class ShoppingCartReportProcessor(readSide: SlickReadSide, repository: ShoppingCartReportRepository, environment: Environment)
     extends ReadSideProcessor[Event] {
 
   override def buildHandler(): ReadSideProcessor.ReadSideHandler[Event] =
@@ -28,7 +31,7 @@ class ShoppingCartReportProcessor(readSide: SlickReadSide, repository: ShoppingC
       .setEventHandler[CartCheckedOut] { envelope =>
         // This is not part of a real application, but we are adding it here to show
         // how Lightbend Telemetry handles failures on Lagom's read-side processors.
-        if (Random.nextInt(5) == 0) throw new RuntimeException("Sometimes event handling a checkout fails.")
+        if (Random.nextInt(5) == 0 && environment.mode != Mode.Test) throw new RuntimeException("Sometimes event handling a checkout fails.")
         repository.addCheckoutTime(envelope.entityId, envelope.event.eventTime)
       }
       .build()


### PR DESCRIPTION
@pyoio turns out I was reading old information and Github Actions is able to access secrets in pull requests. Apparently, it is even smart enough to redact the secrets in build logs. From the [docs](https://docs.github.com/en/actions/configuring-and-managing-workflows/creating-and-storing-encrypted-secrets):

> To help ensure that GitHub redacts your secret in logs, avoid using structured data as the values of secrets. For example, avoid creating secrets that contain JSON or encoded Git blobs.
> ...
> GitHub automatically redacts secrets printed to the log, but you should avoid printing secrets to the log intentionally.

For now, only lagom/shoping-cart-scala is tested since it is the only complete sample we have.

